### PR TITLE
change tile info and highlighter to fit blend style

### DIFF
--- a/board/component/Highlighter.cpp
+++ b/board/component/Highlighter.cpp
@@ -42,20 +42,22 @@ void Highlighter::update()
 
 			TileInfo::HighlightType type = info->getHighlightType();
 
-			int x = info->getPosX();
-			int z = info->getPosY();
+			//int x = info->getPosX();
+			//int z = info->getPosY();
 
-			kitten::QuadRenderable* quad = tile->getComponent<kitten::QuadRenderable>();
+			//kitten::QuadRenderable* quad = tile->getComponent<kitten::QuadRenderable>();
 
 			if (type != TileInfo::None)
 			{
 				//Add blending
-				quad->addTexture(m_texMap[TileInfo::Area].c_str(), 1.0f);
+				info->changeHighlightTexture(m_texMap[type]);
+				//quad->addTexture(m_texMap[type].c_str(), 1.0f);
 			}
 			else
 			{
+				info->changeHighlightTexture("");
 				//Remove blending
-				quad->removeTexture(m_texMap[TileInfo::Area].c_str());
+				//quad->removeTexture(m_texMap[type].c_str());
 			}
 		}
 

--- a/board/tile/TileInfo.cpp
+++ b/board/tile/TileInfo.cpp
@@ -13,7 +13,8 @@ TileInfo::TileInfo(int p_iPosX, int p_iPosY)
 	m_iPosX(p_iPosX),
 	m_iPosY(p_iPosY),
 	m_sOwnerId("NONE"),
-	m_sHighlightedBy("NONE")
+	m_sHighlightedBy("NONE"),
+	m_lasttexpath("")
 {
 	m_unitGO = nullptr;
 	m_landInfo = nullptr;
@@ -72,6 +73,27 @@ void TileInfo::effect(ability::TimePointEvent::TPEventType p_tp, unit::Unit * p_
 	case ability::TimePointEvent::New_Tile:
 		m_landInfo->effectOnPass(p_u);
 		break;
+	}
+}
+
+void TileInfo::changeHighlightTexture(const std::string & p_texpath)
+{
+	if (m_lasttexpath != p_texpath)
+	{
+		kitten::QuadRenderable* quad = m_attachedObject->getComponent<kitten::QuadRenderable>();
+		if (m_lasttexpath != "")
+		{
+			//Remove blending
+			quad->removeTexture(m_lasttexpath.c_str());
+		}
+
+		m_lasttexpath = p_texpath;
+
+		if (m_lasttexpath != "")
+		{
+			//Add new blending
+			quad->addTexture(p_texpath.c_str(), 1.0f);
+		}
 	}
 }
 

--- a/board/tile/TileInfo.h
+++ b/board/tile/TileInfo.h
@@ -34,6 +34,7 @@ public:
 	void effect(ability::TimePointEvent::TPEventType p_tp, unit::Unit* p_u);
 
 	//highlight 
+	void changeHighlightTexture(const std::string& p_texpath);
 	bool isHighlighted(HighlightType p_type);
 	void setHighlighted(HighlightType p_type, bool p_bool);
 	HighlightType getHighlightType();
@@ -65,6 +66,7 @@ private:
 	int m_iPosX, m_iPosY;
 	std::string m_sOwnerId;
 	std::string m_sHighlightedBy;
+	std::string m_lasttexpath;
 
 	LandInformation::TileType m_tileType;
 


### PR DESCRIPTION
I remove actual blend to tile info, because it can remember last highlight, so when it is highlight by new texture or remove highlight, it can remove last highlight texture