### PR TITLE
Power is added on extra draw

### DIFF
--- a/UI/HandFrame.cpp
+++ b/UI/HandFrame.cpp
@@ -119,7 +119,7 @@ namespace userinterface
 		// Add the extras as power
 		if (countToAdd < p_event->getInt(CARD_COUNT))
 		{
-			BoardManager::getInstance()->getPowerTracker()->summonUnitCost(-TEMP_POWER_CHARGE);
+			BoardManager::getInstance()->getPowerTracker()->changeCurrentPower(TEMP_POWER_CHARGE * (p_event->getInt(CARD_COUNT) - countToAdd));
 		}
 
 		reorderAllCards();

--- a/components/PowerTracker.cpp
+++ b/components/PowerTracker.cpp
@@ -86,3 +86,15 @@ int PowerTracker::getCurrentPower()
 {
 	return m_iCurrentPower;
 }
+
+
+bool PowerTracker::changeCurrentPower(int p_iAmount)
+{
+	if ((m_iCurrentPower + p_iAmount) >= 0)
+	{
+		m_iCurrentPower += p_iAmount;
+		return true;
+	}
+
+	return false;
+}

--- a/components/PowerTracker.h
+++ b/components/PowerTracker.h
@@ -20,7 +20,7 @@ public:
 	bool summonUnitCost(int p_iCost);
 	void resetCurrent();
 	void resetEvent(kitten::Event::EventType p_type, kitten::Event* p_data);
-
+	bool changeCurrentPower(int p_iAmount = 0);
 
 	int getMaxPower();
 	int getCurrentPower();	


### PR DESCRIPTION
A card is burned once there's no more space in hand, it'll add a point to temporary power storage.