### PR TITLE
fix issue

### DIFF
--- a/_Project/data/gameobject/cast_timer.json
+++ b/_Project/data/gameobject/cast_timer.json
@@ -2,7 +2,7 @@
     "name" : "Cast Timer", 
     "components" : [
         {
-            "name" : "UIObject"
+            "name" : "SimpleQuadRenderable"
         },
         {
             "name" : "TimerSymbol",
@@ -19,6 +19,6 @@
                 "textures/ui/cast_timer/timer_10.png"]
         }
     ],
-    "scale2d" : [60,60],
-    "translate2d" : [0,15]
+    "scale" : [1,1,1],
+    "translate" : [0,-0.4,0]
 }

--- a/kitten/SimpleQuadRenderable.cpp
+++ b/kitten/SimpleQuadRenderable.cpp
@@ -82,12 +82,12 @@ kitten::SimpleQuadRenderable::SimpleQuadRenderable(const std::string & p_texPath
 		//setup the vao
 		puppy::TexturedVertex verts[] =
 		{
-		{ -0.5f, 0.0f, 0.5f,		0.0f, 1.0f },
-		{ 0.5f, 0.0f, 0.5f,			1.0f, 1.0f },
-		{ 0.5f, 0.0f,-0.5f,			1.0f, 0.0f },
-		{ 0.5f, 0.0f,-0.5f,			1.0f, 0.0f },
-		{ -0.5f, 0.0f,-0.5f,		0.0f, 0.0f },
-		{ -0.5f, 0.0f, 0.5f,		0.0f, 1.0f },
+		{ -0.5f, 0.0f, 0.5f,		1.0f, 1.0f },
+		{ 0.5f, 0.0f, 0.5f,			0.0f, 1.0f },
+		{ 0.5f, 0.0f,-0.5f,			0.0f, 0.0f },
+		{ 0.5f, 0.0f,-0.5f,			0.0f, 0.0f },
+		{ -0.5f, 0.0f,-0.5f,		1.0f, 0.0f },
+		{ -0.5f, 0.0f, 0.5f,		1.0f, 1.0f },
 		};
 		sm_vao = new puppy::VertexEnvironment(verts, puppy::ShaderManager::getShaderProgram(puppy::ShaderType::alphaTest), 6);
 	}

--- a/unit/unitComponent/CastTimer.h
+++ b/unit/unitComponent/CastTimer.h
@@ -20,6 +20,7 @@ namespace unit
 		int changeTimer(int p_n = -1);
 		void cancelCast();
 
+		void cast();
 	private:
 		ability::AbilityInfoPackage* m_pack;
 		std::string m_abilityName;
@@ -29,6 +30,5 @@ namespace unit
 		kitten::K_GameObject* m_timerSymbol;
 		Unit* m_unit;
 
-		void cast();
 	};
 }

--- a/unit/unitComponent/TimerSymbol.cpp
+++ b/unit/unitComponent/TimerSymbol.cpp
@@ -2,7 +2,7 @@
 
 unit::TimerSymbol::TimerSymbol():
 	m_timeTex(std::vector<std::string>(11)),
-	m_ui(nullptr)
+	m_quad(nullptr)
 {
 }
 
@@ -17,14 +17,14 @@ void unit::TimerSymbol::addTexture(int p_num, const std::string & p_texPath)
 
 void unit::TimerSymbol::changeTexture(int p_num)
 {
-	if (m_ui == nullptr)
+	if (m_quad == nullptr)
 		m_tex = m_timeTex[p_num];
 	else
-		m_ui->setTexture(m_timeTex[p_num].c_str());
+		m_quad->setTexture(m_timeTex[p_num].c_str());
 }
 
 void unit::TimerSymbol::start()
 {
-	m_ui = m_attachedObject->getComponent<userinterface::UIObject>();
-	m_ui->setTexture(m_tex.c_str());
+	m_quad = m_attachedObject->getComponent<kitten::SimpleQuadRenderable>();
+	m_quad->setTexture(m_tex.c_str());
 }

--- a/unit/unitComponent/TimerSymbol.h
+++ b/unit/unitComponent/TimerSymbol.h
@@ -6,7 +6,7 @@ It controls which texture to display.
 #pragma once
 #include "kitten/K_Common.h"
 #include "UI/UIObject.h"
-
+#include "kitten/SimpleQuadRenderable.h"
 namespace unit
 {
 	class TimerSymbol : public kitten::K_Component
@@ -22,7 +22,7 @@ namespace unit
 		void start() override;
 	private:
 		std::vector<std::string> m_timeTex;
-		userinterface::UIObject* m_ui;
+		kitten::SimpleQuadRenderable* m_quad;
 		std::string m_tex;
 	};
 }


### PR DESCRIPTION
Thanks for Saleh's suggestion.
I temporarily disable mountain, so I can test stuffs.
(mountain is added back after testing)

Fix 2 issues from last pr.
1. cast() in castTimer is public now.
2. Cast symbol can be correctly displayed.
(Its uv is flipped, so I change vertices in simple quad renderable class, for now I don't see other influence)