### PR TITLE
add token tag

### DIFF
--- a/_Project/data/unit/Priest.json
+++ b/_Project/data/unit/Priest.json
@@ -14,7 +14,6 @@
 				"max_range":2,
 				"need_unit":1,
 				"target":1,
-				"need_unit":1,
 				"description":"Heal target unit 3 HP."
 			},
 			{
@@ -26,7 +25,6 @@
 				"target":1,
 				"need_unit":1,
 				"duration":3,
-				"need_unit":1,
 				"description":"Give target [Encourage]: When dealing damage, deal 1 more damage.",
 				"status_name":"Encourage",
 				"status_description":"Damage Increased."

--- a/_Project/data/unit/Wall.json
+++ b/_Project/data/unit/Wall.json
@@ -5,7 +5,7 @@
 		"mv":0,
 		"in":0,
 		"cost":1,
-		"tags":["Terrans","Structure"],
+		"tags":["Terrans","Structure","token"],
 		"portrait_texture" : "textures/cards/500x500/Wall.tga"
 	},
 	"components" : [

--- a/_Project/data/unit/newUnitObject.json
+++ b/_Project/data/unit/newUnitObject.json
@@ -5,7 +5,7 @@
 		"mv":8,
 		"in":40,
 		"cost":4,
-		"tags": ["Commander","Dummy"],
+		"tags": ["Commander","Dummy","token"],
 		"commander":{
 			"portrait_path" : "place_holder"
 		},

--- a/_Project/data/unit/testDummy.json
+++ b/_Project/data/unit/testDummy.json
@@ -5,7 +5,7 @@
     "in":40,
     "cost":4,
 	"spritename" : "wizard",
-    "tags": ["Commander","Dummy"],
+    "tags": ["Commander","Dummy","token"],
     "ability_description":[
 			{
 				"name":"Blast",


### PR DESCRIPTION
Since most units can be put in deck, I'd rather made a tag for units that shouldn't be in tag.

So I add "token" tag to Wall, newUnitObject, testDummy. They are way less than units that can be in deck.

And newUnitObject and testDummy should be removed. But It will mess around with indexes of units.
Maybe you should add a function that allow me to summon by name? (just suggest)