### PR TITLE
fixed

### DIFF
--- a/unit/InitiativeTracker/InitiativeTrackerUI.cpp
+++ b/unit/InitiativeTracker/InitiativeTrackerUI.cpp
@@ -5,7 +5,10 @@
 #include "UI/UIFrame.h"
 #include "puppy/Text/TextBox.h"
 
-unit::InitiativeTrackerUI::InitiativeTrackerUI():m_lastUnitIndex(0)
+unit::InitiativeTrackerUI::InitiativeTrackerUI()
+	:m_lastUnitIndex(0),
+	m_leftX(-0.5f),
+	m_gap(0.15f)
 {
 	m_initiativeObject = kitten::K_GameObjectManager::getInstance()->createNewGameObject();
 

--- a/unit/InitiativeTracker/InitiativeTrackerUI.h
+++ b/unit/InitiativeTracker/InitiativeTrackerUI.h
@@ -32,8 +32,8 @@ namespace unit
 		kitten::K_GameObject* m_initiativeObject;
 		kitten::K_GameObject* m_pointerObject;
 
-		const float m_gap = 0.175f;//distance from adjacent frame
-		const float m_leftX = -0.25f;//start x coodinate for frame
+		const float m_gap = 0.15f;//distance from adjacent frame
+		const float m_leftX = -0.4f;//start x coodinate for frame
 
 		
 		std::vector<float> m_xList;//the list of x position for each frame slots

--- a/unit/InitiativeTracker/TrackerBlock.cpp
+++ b/unit/InitiativeTracker/TrackerBlock.cpp
@@ -17,7 +17,7 @@ const float unit::TrackerBlock::sm_halfWinY = 720 / 2;
 const float unit::TrackerBlock::sm_textY = 500.0f;
 const int unit::TrackerBlock::sm_offsetY = 0;
 const int unit::TrackerBlock::sm_margin = 10;
-const int unit::TrackerBlock::sm_startX = 300;
+//const int unit::TrackerBlock::sm_startX = 300;
 
 const float unit::TrackerBlock::sm_speed = 0.02f;
 
@@ -99,7 +99,10 @@ void unit::TrackerBlock::move(int p_slotIndex)
 		//place block to the slot directly if it doesn't has slot yet
 		m_currentSlotIndex = p_slotIndex;
 
-		float xx = sm_startX + (m_currentSlotIndex * (offset + sm_margin));
+		//float xx = sm_startX + (m_currentSlotIndex * (offset + sm_margin));
+
+		float x = m_trackerUI->m_xList[m_currentSlotIndex];
+		float xx = sm_halfWinX * (1 + x);
 
 		m_frameObject->getTransform().place2D(xx, m_frameY - sm_margin);
 		//m_textObject->getTransform().place2D(xx, sm_textY);
@@ -109,7 +112,10 @@ void unit::TrackerBlock::move(int p_slotIndex)
 		//if current slot isn't at the target slot's right slot, place block there
 		m_currentSlotIndex = p_slotIndex + 1;
 
-		float xx = sm_startX + (m_currentSlotIndex * offset);
+		//float xx = sm_startX + (m_currentSlotIndex * offset);
+
+		float x = m_trackerUI->m_xList[m_currentSlotIndex];
+		float xx = sm_halfWinX * (1 + x);
 
 		m_frameObject->getTransform().place2D(xx, m_frameY - sm_margin);
 		//m_textObject->getTransform().place2D(xx, sm_textY);
@@ -168,7 +174,7 @@ void unit::TrackerBlock::update()
 				if (distance > velocity)//not close
 				{
 					//convert to text
-					float xx = sm_startX * velocity;
+					float xx = sm_halfWinX * velocity;
 					m_frameObject->getTransform().move2D(xx, 0);
 					//m_textObject->getTransform().move2D(xx,0);
 					distance -= velocity;
@@ -176,7 +182,7 @@ void unit::TrackerBlock::update()
 				else//vecy close, 
 				{
 					//convert to text
-					float xx = sm_startX * distance;
+					float xx = sm_halfWinX * distance;
 					m_frameObject->getTransform().move2D(xx, 0);
 					//m_textObject->getTransform().move2D(xx, 0);
 					distance = 0;

--- a/unit/InitiativeTracker/TrackerBlock.h
+++ b/unit/InitiativeTracker/TrackerBlock.h
@@ -56,7 +56,7 @@ namespace unit
 		const static int sm_offsetY;
 		float m_frameY;//y coodinate for frame
 
-		const static int sm_startX;
+		//const static int sm_startX;
 
 		const static float sm_textY;
 


### PR DESCRIPTION
Several problems cause the issue.

1. when move, sometimes multiply start position instead of half window size.
2. when set tracker block, it only count block width and ignore margin

3. The main reason is tracker block set a static variable of start position. And Initiative Tracker UI also set position of each block. They are different and have conflict. Tracker block using its own start position at setting but still look UI's position when moving, so problem occurs.

My solution is fix the code and remove start position in block. 