### PR TITLE
Fixed MultiTarget Projectiles in Multiplayer

### DIFF
--- a/ability/AbilityInfoPackage.h
+++ b/ability/AbilityInfoPackage.h
@@ -32,7 +32,7 @@ namespace ability
 		kitten::K_GameObject* m_cardGOForUnitSummon = nullptr;
 
 		// Tile (or other clickable) the player clicked on to use ability: used to make projectiles (visually)
-		kitten::K_GameObject* m_clickedObject;
+		kitten::K_GameObject* m_clickedObject = nullptr;
 
 		AbilityInfoPackage() {};
 		~AbilityInfoPackage() {};

--- a/networking/ConnectToHost.cpp
+++ b/networking/ConnectToHost.cpp
@@ -114,7 +114,7 @@ void ConnectToHost::update()
 	}
 
 	// Update ClientGame if there is an instance
-	if (networking::ClientGame::getInstance() != nullptr && networking::ClientGame::isNetworkValid())
+	if (networking::ClientGame::getInstance() != nullptr && networking::ClientGame::isNetworkValid() && !m_bJoiningGame)
 	{
 		networking::ClientGame::getInstance()->update();
 	}

--- a/networking/NetworkData.h
+++ b/networking/NetworkData.h
@@ -293,6 +293,8 @@ private:
 	std::vector<std::pair<int, int>> m_targetTiles;
 	TargetTiles m_targetTilesGO;
 
+	std::pair<int, int> m_clickedObjectPos = { -1, -1 };
+
 	void writeInt(Buffer &p_buffer, int p_value);
 	void writeChar(Buffer &p_buffer, char p_value);
 	int readInt(Buffer &p_buffer);

--- a/unit/unitComponent/CastTimer.cpp
+++ b/unit/unitComponent/CastTimer.cpp
@@ -49,7 +49,11 @@ void unit::CastTimer::set(std::string p_abilityName, ability::AbilityInfoPackage
 
 		m_timerSymbol->getComponent<TimerSymbol>()->changeTexture(m_timer);
 
-		m_pack->m_clickedObject = input::InputManager::getInstance()->getMouseLastHitObject();
+		// If != nullptr, then m_clickedObject was already set by ClientGame/AbilityPacket
+		if (m_pack->m_clickedObject == nullptr)
+		{
+			m_pack->m_clickedObject = input::InputManager::getInstance()->getMouseLastHitObject();
+		}
 	}
 }
 

--- a/unitInteraction/UnitInteractionManager.cpp
+++ b/unitInteraction/UnitInteractionManager.cpp
@@ -162,11 +162,11 @@ void UnitInteractionManager::send()
 	}
 	else//has cast time
 	{//set cast ability
+		m_unit->setCast(m_ad, m_package);
 		if (networking::ClientGame::isNetworkValid())
 		{
 			networking::ClientGame::getInstance()->sendCastTimeAbilityPacket(m_ad, m_package);
 		}
-		m_unit->setCast(m_ad, m_package);
 	}
 
 	m_package = nullptr;


### PR DESCRIPTION
- Projectiles for multitarget abilities now properly target the proper tile for the other player during multiplayer
- Also a small fix in ConnectToHost where it could update ClientGame and attempt access a spawnpoint before the Board had been created