### PR TITLE
Clone ability, Autocast, and Gorefiend issues fixed

### DIFF
--- a/UI/CardContext.cpp
+++ b/UI/CardContext.cpp
@@ -396,14 +396,14 @@ void CardContext::setUnitListener(kitten::Event::EventType p_type, kitten::Event
 		kitten::K_GameObject* unitGO = p_event->getGameObj(UPDATE_CARD_CONTEXT_KEY);
 		if (unitGO != nullptr)
 		{
-			unit::Unit* unit = unitGO->getComponent<unit::Unit>();
-			setUnit(unit);
 			m_updatedByGO = true;
+			unit::Unit* unit = unitGO->getComponent<unit::Unit>();
+			setUnit(unit);			
 		}
 	} else if (p_type == kitten::Event::Update_Card_Context_By_ID)
 	{
-		setUnit(kibble::getUnitFromId(p_event->getInt(UPDATE_CARD_CONTEXT_KEY)));
 		m_updatedByGO = false;
+		setUnit(kibble::getUnitFromId(p_event->getInt(UPDATE_CARD_CONTEXT_KEY)));
 	}
 }
 

--- a/ability/ability/Clone.cpp
+++ b/ability/ability/Clone.cpp
@@ -10,27 +10,28 @@ namespace ability
 {
 	int Clone::effect(AbilityInfoPackage* p_info)
 	{
-		//get card id
-		int cardId = p_info->m_source->m_kibbleID;
+		if (networking::ClientGame::getClientId() == p_info->m_sourceClientId || networking::ClientGame::getClientId() == -1)
+		{
+			//get card id
+			int cardId = p_info->m_source->m_kibbleID;
 
-		//get num
-		int num = p_info->m_intValue[CARD_DRAWN];
+			//get num
+			int num = p_info->m_intValue[CARD_DRAWN];
 
-		//create event
-		kitten::Event* eventData = new kitten::Event(kitten::Event::EventType::Card_Drawn);
+			//create event
+			kitten::Event* eventData = new kitten::Event(kitten::Event::EventType::Card_Drawn);
 
-		std::unordered_map<int, int> cards;
-		cards.insert(std::make_pair(cardId, num));
-		putCardToHand(eventData, cards);
+			std::unordered_map<int, int> cards;
+			cards.insert(std::make_pair(cardId, num));
+			putCardToHand(eventData, cards);
 
-		//queue event
-		kitten::EventManager::getInstance()->triggerEvent(
-			kitten::Event::EventType::Put_Card_To_Hand,
-			eventData
-		);
-
+			//queue event
+			kitten::EventManager::getInstance()->triggerEvent(
+				kitten::Event::EventType::Put_Card_To_Hand,
+				eventData
+			);
+		}
 		UniversalSounds::playSound("single_bubble");
-
 		done(p_info);
 
 		return 0;

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -275,7 +275,7 @@ namespace unit
 		}
 
 		//if has auto cast ability, use it
-		if (m_autoCast)
+		if (m_autoCast && networking::ClientGame::getClientId() == m_clientId)
 		{
 			useAbility(m_autoAbility);
 		}


### PR DESCRIPTION
Issue #422: Slime's Clone ability issue in multiplayer
- Added client ID check to prevent a copy of Slime appearing in the other player's hand
- Sound will still play no matter what so the other player at least has an audio cue of the ability being used

Issue #423 and #424: Autocast/click issues in multiplayer
- Added client ID check before attempting to autocast/click
- closes #423 and closes #424 

Issue #431: Hovering Gorefiend in multiplayer crash
- Flags indicating how to update the CardContext have been moved before setting the unit in the context
