### PR TITLE
Fixed Summoned Tokens Having Wrong Border

### DIFF
--- a/ability/ability/Ability.cpp
+++ b/ability/ability/Ability.cpp
@@ -92,14 +92,9 @@ void ability::Ability::multiTargetProjectileFinished(AbilityInfoPackage* p_packa
 
 kitten::K_GameObject * ability::Ability::summonToken(AbilityInfoPackage* p_info, int p_unitIndex)
 {
-	kitten::K_GameObject* u = unit::UnitSpawn::getInstance()->spawnUnitObject(p_unitIndex);
+	kitten::K_GameObject* u = unit::UnitSpawn::getInstance()->spawnUnitObject(p_unitIndex, p_info->m_sourceClientId);
 	kitten::K_GameObject* tile = p_info->m_targetTilesGO[0];
 	u->getComponent<unit::UnitMove>()->setTile(tile);
-
-	if (networking::ClientGame::getInstance() != nullptr)
-	{
-		u->getComponent<unit::Unit>()->m_clientId = p_info->m_sourceClientId;
-	}
 
 	return u;
 }

--- a/ability/status/Status_Last_Word_Summon.cpp
+++ b/ability/status/Status_Last_Word_Summon.cpp
@@ -23,18 +23,12 @@ int ability::Status_Last_Word_Summon::effect(const TimePointEvent::TPEventType& 
 
 
 		//spawn unit
-		kitten::K_GameObject* u = unit::UnitSpawn::getInstance()->spawnUnitObject(id);
+		kitten::K_GameObject* u = unit::UnitSpawn::getInstance()->spawnUnitObject(id, m_intValue[CLIENT_ID]);
 		unit::Unit* unit = u->getComponent<unit::Unit>();
 
 		//set tile
 		kitten::K_GameObject* tile = m_unit->getTile();
 		u->getComponent<unit::UnitMove>()->setTile(tile);
-
-		//set client id
-		if (networking::ClientGame::getInstance() != nullptr)
-		{
-			unit->m_clientId = m_intValue[CLIENT_ID];
-		}
 
 		//lv up
 		for (int i = 1; i < lv; i++)

--- a/unit/UnitSpawn.cpp
+++ b/unit/UnitSpawn.cpp
@@ -90,8 +90,10 @@ namespace unit
 		return unitObject;
 	}*/
 
-	kitten::K_GameObject* UnitSpawn::spawnUnitObject(const int& p_unitIdentifier) {
-		return spawnUnitObjectInternally(kibble::getUnitInstanceFromId(p_unitIdentifier));
+	kitten::K_GameObject* UnitSpawn::spawnUnitObject(const int& p_unitIdentifier, int p_clientId) {
+		unit::Unit* unit = kibble::getUnitInstanceFromId(p_unitIdentifier);
+		unit->m_clientId = p_clientId;
+		return spawnUnitObjectInternally(unit);
 	}
 
 	kitten::K_GameObject* UnitSpawn::spawnUnitObject(unit::Unit* p_unit) {

--- a/unit/UnitSpawn.h
+++ b/unit/UnitSpawn.h
@@ -47,7 +47,7 @@ namespace unit
 
 		//kitten::K_GameObject* spawnUnitObject(Unit* p_unitData);
 
-		kitten::K_GameObject* spawnUnitObject(const int& p_unitIdentifier); // makes a new copy from id
+		kitten::K_GameObject* spawnUnitObject(const int& p_unitIdentifier, int p_clientId = -1); // makes a new copy from id
 		kitten::K_GameObject* spawnUnitObject(unit::Unit* p_unitIdentifier); // makes  a copy of the unit 
 
 		ActionButtonStore* getActionButtonStorage() { return m_storage; };


### PR DESCRIPTION
Visual Bug - during the turn they were summoned, the IT would show a grey border instead of the appropriate color, though the unit had the correct client ID

Fixed by adding an optional parameter to UnitSpawn::spawnUnitObject that can assign a client ID to the unit before it is added into the IT