### PR TITLE
quick fix

### DIFF
--- a/UI/LandContext.cpp
+++ b/UI/LandContext.cpp
@@ -116,7 +116,7 @@ void LandContext::updateContext()
 			name = "Sand Land";
 			break;
 		case LandInformation::Forest_land:
-			name = "Forest Land";
+			name = "Mud Land";
 			break;
 		case LandInformation::Garden_land:
 			name = "Garden Land";

--- a/_Project/data/map/map/AllMap.json
+++ b/_Project/data/map/map/AllMap.json
@@ -4,13 +4,13 @@
             "name":"default",
             "map":"default.vgmap",
             "image":"textures/map/default.png",
-            "description":"The normal map. There's forest on the center and sand on the side. You have to defeat enemy to win."
+            "description":"The normal map. There's mud pool on the center and sand on the side. You have to defeat enemy to win."
         },
         {
-            "name":"ForestHollow",
-            "map":"ForestHollow.vgmap",
+            "name":"Hollow",
+            "map":"Hollow.vgmap",
             "image":"textures/map/ForestHollow.png",
-            "description":"In the center  of forest, there's a hollow for commanders to control. "
+            "description":"In the center of mud pool, there's a hollow for commanders to control. "
         },
         {
             "name":"River",
@@ -22,7 +22,7 @@
             "name":"NarrowRoad",
             "map":"NarrowRoad.vgmap",
             "image":"textures/map/NarrowRoad.png",
-            "description":"Forest and swamp cover a crystal mine. There's only a narrow road that allow people move through."
+            "description":"Mud and swamp cover a crystal mine. There's only a narrow road that allow people move through."
         }
     ]
 }

--- a/_Project/data/unit/Monument.json
+++ b/_Project/data/unit/Monument.json
@@ -1,6 +1,6 @@
 {
 	"unit":{
-		"name":"Ancient Monument",
+		"name":"Monument",
 		"hp":20,
 		"mv":0,
 		"in":15,

--- a/unit/InitiativeTracker/InitiativeTracker.cpp
+++ b/unit/InitiativeTracker/InitiativeTracker.cpp
@@ -383,7 +383,10 @@ void unit::InitiativeTracker::gameTurnEnd()
 void unit::InitiativeTracker::addExtraTurn(kitten::K_GameObject * p_unit)
 {
 	m_indexOfBreakPoint = m_currentUnitIndex;
-	m_extraTurnUnitList.push_back(p_unit);
+	if (m_extraTurnUnitList.size() == 0)
+		m_extraTurnUnitList.push_back(p_unit);
+	else if (m_extraTurnUnitList.size() == 1)
+		m_extraTurnUnitList[0] = p_unit;
 	m_UI->change(m_currentUnitIndex);
 }
 

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -76,6 +76,7 @@ namespace unit
 		}
 		//m_isStructure = flag;*/
 
+		/*
 		//check if unit has auto cast ability
 		for (auto ad : m_ADList)
 		{
@@ -85,14 +86,14 @@ namespace unit
 				if(found->second)//auto cast property exist and it's 1
 					setAutoAbility(ad->m_stringValue[ABILITY_NAME]);
 			}
-		}
+		}*/
 	}
-
+	/*
 	void Unit::setAutoAbility(const std::string & p_name)
 	{
 		m_autoCast = true;
 		m_autoAbility = p_name;
-	}
+	}*/
 
 	//status
 	/*
@@ -274,11 +275,12 @@ namespace unit
 			m_turn->act = true;
 		}
 
+		/*
 		//if has auto cast ability, use it
 		if (m_autoCast && networking::ClientGame::getClientId() == m_clientId)
 		{
 			useAbility(m_autoAbility);
-		}
+		}*/
 		kitten::Event* eventData = new kitten::Event(kitten::Event::Next_Units_Turn_Start);
 		kitten::EventManager::getInstance()->queueEvent(kitten::Event::Next_Units_Turn_Start, eventData);
 	}

--- a/unit/Unit.h
+++ b/unit/Unit.h
@@ -57,9 +57,9 @@ namespace unit
 		virtual void start() override;
 
 		//set auto cast ability
-		bool m_autoCast = false;
-		std::string m_autoAbility;
-		void setAutoAbility(const std::string& p_name);
+		//bool m_autoCast = false;
+		//std::string m_autoAbility;
+		//void setAutoAbility(const std::string& p_name);
 
 		//item
 		kitten::K_GameObject* m_itemGO;


### PR DESCRIPTION
1. change Ancient Monument to Monument. closes #444
2. change forest to mud. But this only changes name in Land context. Internally it still uses Forest_Land
3. Forgot to test multiple extra turn units' case yesterday. This is a quick fix for that.