### PR TITLE
Disabled Armory Autocast

### DIFF
--- a/UI/CardContext.cpp
+++ b/UI/CardContext.cpp
@@ -99,8 +99,6 @@ void CardContext::start()
 	m_currentNameFont = m_defaultNameFont;
 
 	m_statusContext = gom->createNewGameObject("UI/status_context/status_context.json")->getComponent<StatusContext>();
-	m_statusContext->getGameObject().getTransform().setIgnoreParent(false);
-	m_statusContext->getGameObject().getTransform().setParent(&m_attachedObject->getTransform());
 
 	// Testing
 	setUnit(kibble::getUnitFromId(13));

--- a/_Project/data/unit/Armory.json
+++ b/_Project/data/unit/Armory.json
@@ -12,7 +12,6 @@
 				"power":3,
 				"min_range":0,
 				"max_range":0,
-				"auto_cast":1,
 				"auto_click":1,
 				"need_unit":0,
 				"area_mode":"square",

--- a/networking/ClientGame.cpp
+++ b/networking/ClientGame.cpp
@@ -272,6 +272,13 @@ namespace networking
 				packet.deserialize(buffer);
 				i += packet.getBytes();
 
+				std::stringstream message;
+				message << "Client:" << sm_iClientId << " received ability:";
+				m_log->logMessage(message.str());
+
+				std::string abilityInfo = packet.getFormattedAbilityInfo();
+				m_log->logMessage(abilityInfo);
+
 				if (checkSync(packet.m_sourceUnit.posX, packet.m_sourceUnit.posY))
 				{
 					useAbility(packet);
@@ -280,6 +287,7 @@ namespace networking
 				{
 					sendDesyncedPacket();
 				}
+				
 				break;
 			}
 			case PacketTypes::CAST_TIME_ABILITY_PACKET:
@@ -293,6 +301,13 @@ namespace networking
 				AbilityPacket packet;
 				packet.deserialize(buffer);
 				i += packet.getBytes();
+
+				std::stringstream message;
+				message << "Client:" << sm_iClientId << " received CastTime ability, setting cast for:";
+				m_log->logMessage(message.str());
+
+				std::string abilityInfo = packet.getFormattedAbilityInfo();
+				m_log->logMessage(abilityInfo);
 
 				if (checkSync(packet.m_sourceUnit.posX, packet.m_sourceUnit.posY))
 				{
@@ -532,13 +547,6 @@ namespace networking
 
 	void ClientGame::useAbility(AbilityPacket& p_packet)
 	{
-		std::stringstream message;
-		message << "Client:" << sm_iClientId << " received ability:";
-		m_log->logMessage(message.str());
-
-		std::string abilityInfo = p_packet.getFormattedAbilityInfo();
-		m_log->logMessage(abilityInfo);
-
 		std::string strAbilityName = p_packet.m_abilityName;
 		printf("[Client: %d] using ability: %s\n", sm_iClientId, strAbilityName.c_str());
 
@@ -588,13 +596,6 @@ namespace networking
 
 		unit::AbilityDescription* ad = info->m_source->m_ADMap[p_packet.m_abilityName];
 		info->m_source->setCast(ad, info);
-
-		std::stringstream message;
-		message << "Client:" << sm_iClientId << " received CastTime ability, setting cast for:";
-		m_log->logMessage(message.str());
-
-		std::string abilityInfo = p_packet.getFormattedAbilityInfo();
-		m_log->logMessage(abilityInfo);
 	}
 
 	void ClientGame::sendCastTimeAbilityPacket(unit::AbilityDescription * p_ad, ability::AbilityInfoPackage * p_info)


### PR DESCRIPTION
Disabling autocast on Armory's Arm ability, see issue #423 for more details
- Not sure if we can fix the underlying problem before the deadline, but this will prevent it from occurring in the meantime. 

Some other small changes:
- Reverted setting StatusContext as a child to CardContext: for some reason, if set as a child, it won't re-enable the UI
- Logged ability/cast time ability packets before sync check: previously, if desynced, you wouldn't be able to see the packet that caused the desync in the logs