### PR TITLE
Status context hanging around fix

### DIFF
--- a/UI/CardContext.cpp
+++ b/UI/CardContext.cpp
@@ -27,7 +27,7 @@
 #define P1_COLOR_G 230.0f / 255.0f
 #define P1_COLOR_B 255.0f / 255.0f
 
-CardContext::CardContext(char p_statusContextKey) : m_statusContextKey(p_statusContextKey)
+CardContext::CardContext(char p_statusContextKey) : m_statusContextKey(p_statusContextKey), m_nonLevelStatus(0)
 {
 
 }
@@ -122,10 +122,9 @@ void CardContext::onDisabled()
 	m_attachedObject->setEnabled(false);
 	m_cardTexture->setEnabled(false);
 	m_unitPortrait->setEnabled(false);
-	if (m_nonLevelStatus > 0)
-	{
-		m_statusContext->getGameObject().setEnabled(false);
-	}
+	m_statusContext->getGameObject().setEnabled(false);
+
+	m_nonLevelStatus = 0;
 }
 
 // For testing only, changes the unit on the hovered card by pressing the B key
@@ -150,7 +149,7 @@ void CardContext::update()
 
 void CardContext::setUnit(unit::Unit* p_unit)
 {
-	if (p_unit != m_unitData && p_unit != nullptr)
+	if (p_unit != nullptr)
 	{
 		m_unitData = p_unit;
 		updateUnitData();
@@ -340,6 +339,15 @@ void CardContext::updateUnitStatus()
 		{
 			m_statusContext->updateContext(unitStatusIcons->m_statusList);
 		}
+	}
+
+	if (m_nonLevelStatus > 0 && m_isEnabled)
+	{
+		m_statusContext->getGameObject().setEnabled(true);
+	}
+	else
+	{
+		m_statusContext->getGameObject().setEnabled(false);
 	}
 }
 


### PR DESCRIPTION
closes #470 
always updating card context on hover, always disabling status context when possible
- Rapidly hovering units doesn't affect performance on my machine