### PR TITLE
Change commander die to defeat/victory

### DIFF
--- a/board/tile/gameMode/GameModeManager.cpp
+++ b/board/tile/gameMode/GameModeManager.cpp
@@ -171,11 +171,11 @@ void GameModeManager::checkPoints()
 		kitten::Event* eventData = new kitten::Event(kitten::Event::Network_End_Game);
 		if (clientId == client->getClientId())
 		{
-			eventData->putInt(GAME_END_RESULT, HOST_COMMANDER_DIED);
+			eventData->putInt(GAME_END_RESULT, VICTORY);
 		}
 		else
 		{
-			eventData->putInt(GAME_END_RESULT, CLIENT_COMMANDER_DIED);
+			eventData->putInt(GAME_END_RESULT, DEFEAT);
 		}
 
 		kitten::EventManager::getInstance()->triggerEvent(kitten::Event::Network_End_Game, eventData);

--- a/kitten/event_system/Event.h
+++ b/kitten/event_system/Event.h
@@ -32,8 +32,8 @@
 
 // Networking Events
 #define GAME_END_RESULT "game_end_result_key"
-#define HOST_COMMANDER_DIED 0
-#define CLIENT_COMMANDER_DIED 1
+#define DEFEAT 0
+#define VICTORY 1
 #define PLAYER_DISCONNECTED 2
 #define CLIENT_DESYNCED 3
 

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -590,11 +590,11 @@ namespace unit
 				kitten::Event* eventData = new kitten::Event(kitten::Event::Network_End_Game);
 				if (m_clientId == client->getClientId())
 				{
-					eventData->putInt(GAME_END_RESULT, HOST_COMMANDER_DIED);
+					eventData->putInt(GAME_END_RESULT, DEFEAT);
 				}
 				else
 				{
-					eventData->putInt(GAME_END_RESULT, CLIENT_COMMANDER_DIED);
+					eventData->putInt(GAME_END_RESULT, VICTORY);
 				}
 				
 				kitten::EventManager::getInstance()->triggerEvent(kitten::Event::Network_End_Game, eventData);

--- a/unit/UnitTest.cpp
+++ b/unit/UnitTest.cpp
@@ -184,13 +184,13 @@ namespace unit
 //		kitten::K_GameObject* u20 = UnitSpawn::getInstance()->spawnUnitObject(24);//gorefiend
 //		u20->getComponent<unit::UnitMove>()->setTile(2, 4);
 
-		kitten::K_GameObject* u21 = UnitSpawn::getInstance()->spawnUnitObject(29);//eldritch lord
-		u21->getComponent<unit::UnitMove>()->setTile(4, 7);
-		u21->getComponent<unit::Unit>()->m_clientId = 0;
+//		kitten::K_GameObject* u21 = UnitSpawn::getInstance()->spawnUnitObject(29);//eldritch lord
+//		u21->getComponent<unit::UnitMove>()->setTile(4, 7);
+//		u21->getComponent<unit::Unit>()->m_clientId = 0;
 
-		kitten::K_GameObject* u22 = UnitSpawn::getInstance()->spawnUnitObject(25);//monument
-		u22->getComponent<unit::UnitMove>()->setTile(5, 4);
-		u22->getComponent<unit::Unit>()->m_clientId = 0;
+//		kitten::K_GameObject* u22 = UnitSpawn::getInstance()->spawnUnitObject(25);//monument
+//		u22->getComponent<unit::UnitMove>()->setTile(5, 4);
+//		u22->getComponent<unit::Unit>()->m_clientId = 0;
 
 		//test unit 
 		//unit::Unit* u = u1->getComponent<unit::Unit>();

--- a/unit/UnitTest.cpp
+++ b/unit/UnitTest.cpp
@@ -184,8 +184,13 @@ namespace unit
 //		kitten::K_GameObject* u20 = UnitSpawn::getInstance()->spawnUnitObject(24);//gorefiend
 //		u20->getComponent<unit::UnitMove>()->setTile(2, 4);
 
-//		kitten::K_GameObject* u21 = UnitSpawn::getInstance()->spawnUnitObject(29);//eldritch lord
-//		u21->getComponent<unit::UnitMove>()->setTile(4, 7);
+		kitten::K_GameObject* u21 = UnitSpawn::getInstance()->spawnUnitObject(29);//eldritch lord
+		u21->getComponent<unit::UnitMove>()->setTile(4, 7);
+		u21->getComponent<unit::Unit>()->m_clientId = 0;
+
+		kitten::K_GameObject* u22 = UnitSpawn::getInstance()->spawnUnitObject(25);//monument
+		u22->getComponent<unit::UnitMove>()->setTile(5, 4);
+		u22->getComponent<unit::Unit>()->m_clientId = 0;
 
 		//test unit 
 		//unit::Unit* u = u1->getComponent<unit::Unit>();


### PR DESCRIPTION
Game end condition check in Unit::Destroy() checks loser.
But in game mode manager it checks winner.
So I reverse what in game mode manager. And change Macro name to make more sense.
I think close #469