### PR TITLE
add observer pattern

### DIFF
--- a/ability/status/Status.cpp
+++ b/ability/status/Status.cpp
@@ -56,6 +56,14 @@ namespace ability
 		}
 	}
 
+	void Status::tryDeregisterDestroy()
+	{
+		if (m_caster != nullptr)//has registered to units
+		{
+			m_caster->deregisterDestroy(this);
+		}
+	}
+
 	Status::Status()
 		:m_caster(nullptr),
 		m_unit(nullptr)
@@ -64,7 +72,8 @@ namespace ability
 
 	Status::~Status()
 	{
-		//effectEnd();
+		//deregister from observered
+		tryDeregisterDestroy();
 	}
 
 	void Status::changeName(const std::string & p_msg)

--- a/ability/status/Status.cpp
+++ b/ability/status/Status.cpp
@@ -43,6 +43,19 @@ namespace ability
 		}
 	}
 
+	void Status::notifyUnitDestroy(unit::Unit * p_u)
+	{
+		tryRemoveCaster(p_u);
+	}
+
+	void Status::tryRemoveCaster(unit::Unit * p_u)
+	{
+		if (p_u == m_caster)
+		{
+			m_caster = nullptr;
+		}
+	}
+
 	Status::Status()
 		:m_caster(nullptr),
 		m_unit(nullptr)
@@ -116,6 +129,7 @@ namespace ability
 	void Status::setCaster(unit::Unit * p_u)
 	{
 		m_caster = p_u;
+		p_u->registerDestroy(this);
 	}
 
 	void Status::endEffectAt(const TimePointEvent::TPEventType& p_value)

--- a/ability/status/Status.h
+++ b/ability/status/Status.h
@@ -97,6 +97,8 @@ namespace ability
 		//for test
 		void print();
 
+		//register detroy notifier
+		void notifyUnitDestroy(unit::Unit* p_u);
 	protected:
 		//the text that will be showed to player
 		std::string m_name;
@@ -143,6 +145,9 @@ namespace ability
 
 		//actually change
 		void changeEffectedAD(bool p_reverse = false);
+
+
+		void tryRemoveCaster(unit::Unit* p_u);
 	};
 
 	/*

--- a/ability/status/Status.h
+++ b/ability/status/Status.h
@@ -148,6 +148,8 @@ namespace ability
 
 
 		void tryRemoveCaster(unit::Unit* p_u);
+
+		void tryDeregisterDestroy();
 	};
 
 	/*
@@ -341,7 +343,6 @@ namespace ability
 		Status_Vampiric_Curse();
 		Status* clone() const { return new Status_Vampiric_Curse(*this); };
 		int effect(const TimePointEvent::TPEventType& p_type, ability::TimePointEvent* p_event);
-		//void setCaster(unit::Unit* p_u);
 	};
 
 	/*

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -639,6 +639,27 @@ namespace unit
 		m_statusObserverList.push_back(p_status);
 	}
 
+	void Unit::deregisterDestroy(ability::Status * p_status)
+	{
+		if (!m_hasObserver)//ignore it since no observer
+			return;
+
+		auto end = m_statusObserverList.end();
+		for (auto it = m_statusObserverList.begin(); it != end; it++)
+		{
+			if (*it == p_status)//found it
+			{
+				//remove it
+				m_statusObserverList.erase(it);
+				break;
+			}
+		}
+
+		//check if no observer
+		if (m_statusObserverList.size() == 0)
+			m_hasObserver = false;
+	}
+
 	//hp bar
 	void Unit::onScaleLerpFinished(kitten::K_GameObject* p_obj) //Called when healthbar is done animating
 	{

--- a/unit/Unit.cpp
+++ b/unit/Unit.cpp
@@ -15,7 +15,8 @@
 
 namespace unit
 {
-	Unit::Unit() : m_healthBarState(none), m_healthBar(nullptr), m_unitSelect(nullptr), m_lateDestroy(false), m_queuedDestroy(false), m_framesToWaitForDestroy(1)
+	Unit::Unit() : m_healthBarState(none), m_healthBar(nullptr), m_unitSelect(nullptr), m_lateDestroy(false), m_queuedDestroy(false), m_framesToWaitForDestroy(1),
+		m_hasObserver(false)
 	{
 		m_itemGO = nullptr;
 
@@ -559,6 +560,15 @@ namespace unit
 		//trigger unit destroy event
 		triggerTP(ability::TimePointEvent::Unit_Destroy);
 
+		//notify observer
+		if (m_hasObserver)
+		{
+			for (auto status : m_statusObserverList)
+			{
+				status->notifyUnitDestroy(this);
+			}
+		}
+
 		//remove from intiative tracker
 		InitiativeTracker::getInstance()->removeUnit(m_attachedObject);
 	}
@@ -621,6 +631,12 @@ namespace unit
 	kitten::K_GameObject * Unit::getItem() const
 	{
 		return m_itemGO;
+	}
+
+	void Unit::registerDestroy(ability::Status * p_status)
+	{
+		m_hasObserver = true;
+		m_statusObserverList.push_back(p_status);
 	}
 
 	//hp bar

--- a/unit/Unit.h
+++ b/unit/Unit.h
@@ -171,5 +171,6 @@ namespace unit
 
 		//register observer
 		void registerDestroy(ability::Status* p_status);
+		void deregisterDestroy(ability::Status* p_status);
 	};
 }

--- a/unit/Unit.h
+++ b/unit/Unit.h
@@ -65,6 +65,10 @@ namespace unit
 
 		//item
 		kitten::K_GameObject* m_itemGO;
+
+		//status from other units that care about this unit
+		std::vector<ability::Status*> m_statusObserverList;
+		bool m_hasObserver;
 	public:
 		//members
 
@@ -164,5 +168,8 @@ namespace unit
 		void addItem(kitten::K_GameObject* p_item);
 		void removeItem();
 		kitten::K_GameObject* getItem() const;
+
+		//register observer
+		void registerDestroy(ability::Status* p_status);
 	};
 }

--- a/unit/UnitTest.cpp
+++ b/unit/UnitTest.cpp
@@ -169,8 +169,8 @@ namespace unit
 //		kitten::K_GameObject* u17 = UnitSpawn::getInstance()->spawnUnitObject(21);//evil fiend
 //		u17->getComponent<unit::UnitMove>()->setTile(6, 3);
 
-//		kitten::K_GameObject* u18 = UnitSpawn::getInstance()->spawnUnitObject(22);//horror lord
-//		u18->getComponent<unit::UnitMove>()->setTile(5, 4);
+		kitten::K_GameObject* u18 = UnitSpawn::getInstance()->spawnUnitObject(22);//horror lord
+		u18->getComponent<unit::UnitMove>()->setTile(5, 4);
 
 //		kitten::K_GameObject* u19 = UnitSpawn::getInstance()->spawnUnitObject(23);//wraith
 //		u19->getComponent<unit::UnitMove>()->setTile(7, 1);
@@ -188,8 +188,8 @@ namespace unit
 //		u21->getComponent<unit::UnitMove>()->setTile(4, 7);
 //		u21->getComponent<unit::Unit>()->m_clientId = 0;
 
-//		kitten::K_GameObject* u22 = UnitSpawn::getInstance()->spawnUnitObject(25);//monument
-//		u22->getComponent<unit::UnitMove>()->setTile(5, 4);
+		kitten::K_GameObject* u22 = UnitSpawn::getInstance()->spawnUnitObject(25);//monument
+		u22->getComponent<unit::UnitMove>()->setTile(6, 4);
 //		u22->getComponent<unit::Unit>()->m_clientId = 0;
 
 		//test unit 


### PR DESCRIPTION
fix #467 
Add observer pattern.
Unit will notify status when destroyed, so status::m_caster will set to nullptr.